### PR TITLE
[FixBug] Fixed undefined method "set" to "setOption"

### DIFF
--- a/src/Console/Application/Console.php
+++ b/src/Console/Application/Console.php
@@ -64,7 +64,7 @@ class Console extends \Windwalker\Console\Console
 		// Make Windows no ANSI color
 		if (defined('PHP_WINDOWS_VERSION_BUILD'))
 		{
-			$io->set('ansi', true);
+			$io->setOption('ansi', true);
 		}
 
 		\JFactory::$application = $this;


### PR DESCRIPTION
Fix bug with the error as below

```
Fatal error: Call to undefined method Windwalker\Console\IO\IO::set()
```

It occurs in Windows environment
