### PR TITLE
New ArrayHelper::query() and test

### DIFF
--- a/src/Helper/ArrayHelper.php
+++ b/src/Helper/ArrayHelper.php
@@ -8,13 +8,14 @@
 
 namespace Windwalker\Helper;
 
-use JArrayHelper;
+use Windwalker\String\Utf8String;
+use \Windwalker\Utilities\ArrayHelper as WindwalkerArrayHelper;
 
 // No direct access
 defined('_JEXEC') or die;
 
 /**
- * Enhance JArrayHelper, and add some useful functions.
+ * Enhance static, and add some useful functions.
  *
  * @since 2.0
  */
@@ -206,7 +207,7 @@ class ArrayHelper
 		{
 			if (strpos($key, $prefix) === 0)
 			{
-				$key2 = \JString::substr($key, \JString::strlen($prefix));
+				$key2 = Utf8String::substr($key, Utf8String::strlen($prefix));
 				self::setValue($target, $key2, $row);
 			}
 		}
@@ -326,35 +327,35 @@ class ArrayHelper
 
 				if (substr($val, -2) == '>=')
 				{
-					if (JArrayHelper::getValue($data, $key) >= substr($val, 0, -2))
+					if (static::getValue($data, $key) >= substr($val, 0, -2))
 					{
 						$value = $v;
 					}
 				}
 				elseif (substr($val, -2) == '<=')
 				{
-					if (JArrayHelper::getValue($data, $key) <= substr($val, 0, -2))
+					if (static::getValue($data, $key) <= substr($val, 0, -2))
 					{
 						$value = $v;
 					}
 				}
 				elseif (substr($val, -1) == '>')
 				{
-					if (JArrayHelper::getValue($data, $key) > substr($val, 0, -1))
+					if (static::getValue($data, $key) > substr($val, 0, -1))
 					{
 						$value = $v;
 					}
 				}
 				elseif (substr($val, -1) == '<')
 				{
-					if (JArrayHelper::getValue($data, $key) < substr($val, 0, -1))
+					if (static::getValue($data, $key) < substr($val, 0, -1))
 					{
 						$value = $v;
 					}
 				}
 				else
 				{
-					if (JArrayHelper::getValue($data, $key) == $val)
+					if (static::getValue($data, $key) == $val)
 					{
 						$value = $v;
 					}
@@ -402,7 +403,7 @@ class ArrayHelper
 	}
 
 	/**
-	 * A function like JArrayHelper::getValue(), but support object.
+	 * A function similar to JArrayHelper::getValue(), but support object.
 	 *
 	 * @param   mixed  &$array   An array or object to getValue.
 	 * @param   string $key      Array key to get value.
@@ -414,7 +415,7 @@ class ArrayHelper
 	{
 		if (is_array($array))
 		{
-			return JArrayHelper::getValue($array, $key, $default);
+			return WindwalkerArrayHelper::getValue($array, $key, $default);
 		}
 
 		// If not Array, we do not detect it for warning not Object

--- a/test/Helper/ArrayHelperTest.php
+++ b/test/Helper/ArrayHelperTest.php
@@ -62,7 +62,7 @@ class ArrayHelperTest extends \PHPUnit_Framework_TestCase
 		// Test null return
 		$this->assertEquals(null, ArrayHelper::getByPath($data, ''));
 		$this->assertEquals(null, ArrayHelper::getByPath($data, null));
-		$this->assertEquals(null, ArrayHelper::getByPath($data, []));
+		$this->assertEquals(null, ArrayHelper::getByPath($data, array()));
 		$this->assertEquals(null, ArrayHelper::getByPath($data, new \stdClass));
 
 		// Test paths
@@ -361,12 +361,70 @@ class ArrayHelperTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, ArrayHelper::pivotToTwoDimension($origin, $keys));
 	}
 
+	/**
+	 * Method to test query()
+	 *
+	 * @covers  \Windwalker\Helper\ArrayHelper::query
+	 *
+	 * @return  void
+	 */
 	public function testQuery()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete(
-			'This test has not been implemented yet.'
+		$data = array(
+			array(
+				'id' => 1,
+				'title' => 'Julius Caesar',
+				'data' => (object) array('foo' => 'bar'),
+			),
+			array(
+				'id' => 2,
+				'title' => 'Macbeth',
+				'data' => array(),
+			),
+			array(
+				'id' => 3,
+				'title' => 'Othello',
+				'data' => 123,
+			),
+			array(
+				'id' => 4,
+				'title' => 'Hamlet',
+				'data' => true,
+			),
 		);
+
+		// Test id equals
+		$this->assertEquals(array($data[1]), ArrayHelper::query($data, array('id' => 2)));
+
+		// Test strict equals
+		$this->assertEquals(array($data[0], $data[2], $data[3]), ArrayHelper::query($data, array('data' => true), false));
+		$this->assertEquals(array($data[3]), ArrayHelper::query($data, array('data' => true), true));
+
+		// Test id GT
+		$this->assertEquals(array($data[1], $data[2], $data[3]), ArrayHelper::query($data, array('id >' => 1)));
+
+		// Test id GTE
+		$this->assertEquals(array($data[1], $data[2], $data[3]), ArrayHelper::query($data, array('id >=' => 2)));
+
+		// Test id LT
+		$this->assertEquals(array($data[0], $data[1]), ArrayHelper::query($data, array('id <' => 3)));
+
+		// Test id LTE
+		$this->assertEquals(array($data[0], $data[1]), ArrayHelper::query($data, array('id <=' => 2)));
+
+		// Test array equals
+		$this->assertEquals(array($data[1]), ArrayHelper::query($data, array('data' => array())));
+
+		// Test object equals
+		$object = new \stdClass;
+		$object->foo = 'bar';
+		$this->assertEquals(array($data[0], $data[3]), ArrayHelper::query($data, array('data' => $object)));
+
+		// Test object strict equals
+		$this->assertEquals(array($data[0]), ArrayHelper::query($data, array('data' => $data[0]['data']), true));
+
+		// Test Keep Key
+		$this->assertEquals(array(1 => $data[1], 2 => $data[2], 3 => $data[3]), ArrayHelper::query($data, array('id >=' => 2), false, true));
 	}
 
 	/**


### PR DESCRIPTION
完成 `query()` method

使用方式

``` php
$newArray = ArrayHelper::query($data, ['id' => 1]);
$newArray = ArrayHelper::query($data, ['id <' => 5]);
$newArray = ArrayHelper::query($data, ['id >=' => 3]);
$newArray = ArrayHelper::query($data, ['bool' => true], true); // Strict
$newArray = ArrayHelper::query($data, ['id >=' => 3], false, true); // Keep key
```

@LeoOnTheEarth please review this.
