### PR TITLE
[FixBug] Should resolve alias key before get raw DI information

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -116,9 +116,8 @@ class Container extends JoomlaContainer
 	 */
 	public function get($key, $forceNew = false)
 	{
-		$raw = $this->getRaw($key);
-
 		$key = $this->resolveAlias($key);
+		$raw = $this->getRaw($key);
 
 		if (is_null($raw))
 		{


### PR DESCRIPTION
跑 PHPUnit 時找到的問題
要改成先找到 alias 的 key 才可以去取得 DI 的資訊
