### PR TITLE
[Update #35]add htmlBuilderTest

### DIFF
--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -50,7 +50,7 @@ class HtmlBuilder
 		{
 			if ($value !== null && $value !== false && $value !== '')
 			{
-				$tag .= ' ' . $key . '=' . String::quote($value, '""');
+				$tag .= ' ' . $key . '=' . String::quote($value, '"');
 			}
 		}
 

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -48,7 +48,14 @@ class HtmlBuilder
 
 		foreach ((array) $attribs as $key => $value)
 		{
-			if ($value !== null && $value !== false && $value !== '')
+			if ($value === true)
+			{
+				$tag .= ' ' . $key;
+
+				continue;
+			}
+
+			if ($value !== null && $value !== false)
 			{
 				$tag .= ' ' . $key . '=' . String::quote($value, '"');
 			}

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -48,13 +48,6 @@ class HtmlBuilder
 
 		foreach ((array) $attribs as $key => $value)
 		{
-			if (is_int($key))
-			{
-				$tag .= ' ' . $value;
-
-				continue;
-			}
-
 			if ($value !== null && $value !== false && $value !== '')
 			{
 				$tag .= ' ' . $key . '=' . String::quote($value, '"');

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -48,6 +48,13 @@ class HtmlBuilder
 
 		foreach ((array) $attribs as $key => $value)
 		{
+			if (is_int($key))
+			{
+				$tag .= ' ' . $value;
+
+				continue;
+			}
+
 			if ($value !== null && $value !== false && $value !== '')
 			{
 				$tag .= ' ' . $key . '=' . String::quote($value, '"');

--- a/test/Html/HtmlBuilderTest.php
+++ b/test/Html/HtmlBuilderTest.php
@@ -79,11 +79,11 @@ class HtmlBuilderTest extends \PHPUnit_Framework_TestCase
 			// select>option*2
 			array(
 				'select',
-				HtmlBuilder::create('option', 'BOY', array('value' => 1, 'selected'))
+				HtmlBuilder::create('option', 'BOY', array('value' => 1, 'selected' => 'selected'))
 				. HtmlBuilder::create('option', 'GIRL', array('value' => 2)),
 				array('id' => 'test-id', 'class' => 'test-class'),
 				'<select id="test-id" class="test-class">
-					<option value="1" selected>BOY</option>
+					<option value="1" selected="selected">BOY</option>
 					<option value="2">GIRL</option>
 				</select>'
 			),
@@ -105,8 +105,8 @@ class HtmlBuilderTest extends \PHPUnit_Framework_TestCase
 			array(
 				'video',
 				'',
-				array('id' => 'test-id', 'controls', 'muted'),
-				'<video id="test-id" controls muted></video>'
+				array('id' => 'test-id', 'controls' => 'true', 'muted' => 'true'),
+				'<video id="test-id" controls="true" muted="true"></video>'
 			)
 		);
 	}

--- a/test/Html/HtmlBuilderTest.php
+++ b/test/Html/HtmlBuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Part of Windwalker project Test files.
+ *
+ * @copyright  Copyright (C) 2011 - 2014 SMS Taiwan, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Windwalker\Test\Helper;
+
+use Windwalker\Html\HtmlBuilder;
+
+/**
+ * Test class of Windwalker\Helper\ArrayHelper
+ *
+ * @since 2.0
+ */
+class HtmlBuilderTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * testCreate
+	 *
+	 * @covers \Windwalker\Html\HtmlBuilder::create()
+	 */
+	public function testCreate()
+	{
+		// Prepare attributes, (目前加 $attributes 參數 render 後會多一個雙引號, 之後再補上相關 test)
+		$id = 'test-id';
+		$className = 'test-class';
+		$attributes = ['id' => $id, 'class' => $className];
+
+		// Test paired tags
+		$pairedTags = $this->getPairedTags();
+
+		foreach ($pairedTags as $pairedTag)
+		{
+			$tagName = $pairedTag;
+			$innerText = 'hello world';
+
+			$element = HtmlBuilder::create($tagName, $innerText);
+
+			// Remove redundant white spaces
+			$trimmedElement = preg_replace('/\s+/', ' ', $element);
+
+			$pattern = '#<' . $tagName . '>(.*?)</' . $tagName . '>#';
+			$matchResult = preg_match($pattern, $trimmedElement, $matches);
+
+			// Test open and close tag and innerText
+			$this->assertTrue(true, $matchResult);
+			$this->assertEquals($innerText, trim($matches[1]));
+		}
+
+		// Check single tag
+		$singleTags = $this->getSingleTags();
+
+		foreach ($singleTags as $singleTag)
+		{
+			$tagName = $singleTag;
+
+			$element = HtmlBuilder::create($tagName, '', $attributes);
+
+			$pattern = '#<' . $tagName . ' />#';
+			$matchResult = preg_match($pattern, $element, $matches);
+
+			// Check open tag
+			$this->assertTrue(true, $matchResult);
+		}
+	}
+
+	/**
+	 * getPairedTags
+	 *
+	 * @return  array
+	 */
+	public function getPairedTags()
+	{
+		return array('p', 'a', 'div', 'h1', 'form', 'li', 'ul', 'table', 'style', 'script');
+	}
+
+	/**
+	 * getSingleTags
+	 *
+	 * @return  array
+	 */
+	public function getSingleTags()
+	{
+		return array('input', 'img');
+	}
+}

--- a/test/Html/HtmlBuilderTest.php
+++ b/test/Html/HtmlBuilderTest.php
@@ -6,7 +6,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Windwalker\Test\Helper;
+namespace Windwalker\Test\Html;
 
 use Windwalker\Html\HtmlBuilder;
 

--- a/test/Html/HtmlBuilderTest.php
+++ b/test/Html/HtmlBuilderTest.php
@@ -57,7 +57,7 @@ class HtmlBuilderTest extends \PHPUnit_Framework_TestCase
 		{
 			$tagName = $singleTag;
 
-			$element = HtmlBuilder::create($tagName, '', $attributes);
+			$element = HtmlBuilder::create($tagName);
 
 			$pattern = '#<' . $tagName . ' />#';
 			$matchResult = preg_match($pattern, $element, $matches);

--- a/test/Html/HtmlBuilderTest.php
+++ b/test/Html/HtmlBuilderTest.php
@@ -79,11 +79,11 @@ class HtmlBuilderTest extends \PHPUnit_Framework_TestCase
 			// select>option*2
 			array(
 				'select',
-				HtmlBuilder::create('option', 'BOY', array('value' => 1, 'selected' => 'selected'))
+				HtmlBuilder::create('option', 'BOY', array('value' => 1, 'selected' => true))
 				. HtmlBuilder::create('option', 'GIRL', array('value' => 2)),
 				array('id' => 'test-id', 'class' => 'test-class'),
 				'<select id="test-id" class="test-class">
-					<option value="1" selected="selected">BOY</option>
+					<option value="1" selected>BOY</option>
 					<option value="2">GIRL</option>
 				</select>'
 			),
@@ -105,8 +105,8 @@ class HtmlBuilderTest extends \PHPUnit_Framework_TestCase
 			array(
 				'video',
 				'',
-				array('id' => 'test-id', 'controls' => 'true', 'muted' => 'true'),
-				'<video id="test-id" controls="true" muted="true"></video>'
+				array('id' => 'test-id', 'controls' => true, 'muted' => true),
+				'<video id="test-id" controls muted></video>'
 			)
 		);
 	}


### PR DESCRIPTION
For #35 
- Add HtmlBuilderTest
  - 另外我發現 `HtmlBuilder::create()` 如果送 `$attributes` 進去的話, render 出來會多一層雙引號, 原本我是要連 `$attributes` 的 test case 一起寫, 但先問問 @asika32764 這怎麼辦好了
    ![screen shot 2015-03-31 at 12 10 33](https://cloud.githubusercontent.com/assets/2177826/6900815/bde5739a-d73b-11e4-8a9d-d2b5f744090f.png)
  - 然後 `HtmlBuilder::create()` 有錯字 .... =_=
    ![screen_shot_2015-03-31_at_ 12_20_36](https://cloud.githubusercontent.com/assets/2177826/6900825/d1fade06-d73b-11e4-9937-f4ffb9631243.png)
