### PR TITLE
[Test] Model 測試與新功能

### DIFF
--- a/bundles/GeneratorBundle/Template/test/testClass.php
+++ b/bundles/GeneratorBundle/Template/test/testClass.php
@@ -9,7 +9,7 @@
 namespace {{ test.class.namespace }};
 
 /**
- * Test class of {className}
+ * Test class of \{{ origin.class.name }}
  *
  * @since {DEPLOY_VERSION}
  */
@@ -18,7 +18,7 @@ class {{ test.class.shortname }} extends \PHPUnit_Framework_TestCase
 	/**
 	 * Test instance.
 	 *
-	 * @var {className}
+	 * @var \{{ origin.class.name }}
 	 */
 	protected $instance;
 
@@ -30,7 +30,7 @@ class {{ test.class.shortname }} extends \PHPUnit_Framework_TestCase
 	 */
 	protected function setUp()
 	{
-		$this->instance = new {{ origin.class.name }};
+		$this->instance = new \{{ origin.class.name }};
 	}
 
 	/**

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -409,6 +409,7 @@ class Model extends \JModelDatabase implements ContainerAwareInterface, \ArrayAc
 	public function set($key, $value)
 	{
 		$this->state->set($key, $value);
+
 		return $this;
 	}
 

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -10,14 +10,16 @@ namespace Windwalker\Model;
 
 use Joomla\DI\Container as JoomlaContainer;
 use Joomla\DI\ContainerAwareInterface;
+use Joomla\Registry\Registry;
 use Windwalker\DI\Container;
+use Windwalker\Helper\ArrayHelper;
 
 /**
  * Windwalker basic model class.
  *
  * @since 2.0
  */
-class Model extends \JModelDatabase implements ContainerAwareInterface
+class Model extends \JModelDatabase implements ContainerAwareInterface, \ArrayAccess
 {
 	/**
 	 * The model (base) name
@@ -68,13 +70,15 @@ class Model extends \JModelDatabase implements ContainerAwareInterface
 	 *
 	 * @param   array              $config    An array of configuration options (name, state, dbo, table_path, ignore_request).
 	 * @param   JoomlaContainer    $container Service container.
-	 * @param   \JRegistry         $state     The model state.
+	 * @param   Registry           $state     The model state.
 	 * @param   \JDatabaseDriver   $db        The database adapter.
 	 *
 	 * @throws \Exception
 	 */
-	public function __construct($config = array(), JoomlaContainer $container = null, \JRegistry $state = null, \JDatabaseDriver $db = null)
+	public function __construct($config = array(), JoomlaContainer $container = null, Registry $state = null, \JDatabaseDriver $db = null)
 	{
+		$this->prefix = !empty($config['prefix']) ? $config['prefix'] : $this->prefix;
+
 		// Guess the option from the class name (Option)Model(View).
 		if (empty($this->prefix))
 		{
@@ -91,19 +95,19 @@ class Model extends \JModelDatabase implements ContainerAwareInterface
 		$this->option = 'com_' . $this->prefix;
 
 		// Guess name
-		$this->name = $this->name ? : \JArrayHelper::getValue($config, 'name', $this->getName());
+		$this->name = $this->name ? : ArrayHelper::getValue($config, 'name', $this->getName());
 
 		// Register the paths for the form
 		$this->registerTablePaths($config);
 
 		// Set the clean cache event
-		$this->eventCleanCache = $this->eventCleanCache ? : \JArrayHelper::getValue($config, 'event_clean_cache', 'onContentCleanCache');
+		$this->eventCleanCache = $this->eventCleanCache ? : ArrayHelper::getValue($config, 'event_clean_cache', 'onContentCleanCache');
 
 		$this->container = $container ? : $this->getContainer();
 
-		$state = new \JRegistry($config);
-
 		parent::__construct($state, $db);
+
+		$this->state->loadArray($config);
 
 		// Guess the context as Option.ModelName.
 		$this->context = $this->context ? : strtolower($this->option . '.' . $this->getName());
@@ -241,7 +245,7 @@ class Model extends \JModelDatabase implements ContainerAwareInterface
 	 */
 	protected function populateState()
 	{
-		$this->loadState();
+		// $this->loadState();
 	}
 
 	/**
@@ -375,5 +379,110 @@ class Model extends \JModelDatabase implements ContainerAwareInterface
 		$this->container = $container;
 
 		return $this;
+	}
+
+	/**
+	 * Get value from a state key.
+	 *
+	 * @param string $key      Key to get this value.
+	 * @param mixed  $default  Default value if key not exists.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   2.1
+	 */
+	public function get($key, $default = null)
+	{
+		return $this->state->get($key, $default);
+	}
+
+	/**
+	 * Set value to state.
+	 *
+	 * @param string $key    Key of this state.
+	 * @param mixed  $value  Value of this state.
+	 *
+	 * @return  static  Return self to support chaining.
+	 *
+	 * @since   2.1
+	 */
+	public function set($key, $value)
+	{
+		$this->state->set($key, $value);
+		return $this;
+	}
+
+	/**
+	 * Reset the state.
+	 *
+	 * @return  static  Return self to support chaining.
+	 *
+	 * @since   2.1
+	 */
+	public function reset()
+	{
+		$this->state = $this->loadState();
+
+		return $this;
+	}
+
+	/**
+	 * Is a property exists or not.
+	 *
+	 * @param mixed $offset Offset key.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   2.1
+	 */
+	public function offsetExists($offset)
+	{
+		return $this->state->exists($offset);
+	}
+
+	/**
+	 * Get a property.
+	 *
+	 * @param mixed $offset Offset key.
+	 *
+	 * @throws  \InvalidArgumentException
+	 * @return  mixed The value to return.
+	 *
+	 * @since   2.1
+	 */
+	public function offsetGet($offset)
+	{
+		return $this->state->get($offset);
+	}
+
+	/**
+	 * Set a value to property.
+	 *
+	 * @param mixed $offset Offset key.
+	 * @param mixed $value  The value to set.
+	 *
+	 * @throws  \InvalidArgumentException
+	 * @return  void
+	 *
+	 * @since   2.1
+	 */
+	public function offsetSet($offset, $value)
+	{
+		$this->state->set($offset, $value);
+	}
+
+	/**
+	 * Unset a property.
+	 *
+	 * @param mixed $offset Offset key to unset.
+	 *
+	 * @throws  \InvalidArgumentException
+	 * @return  void
+	 *
+	 * @since   2.1
+	 */
+	public function offsetUnset($offset)
+	{
+		$this->state->set($offset, null);
 	}
 }

--- a/test/Joomla/MockDatabaseDriver.php
+++ b/test/Joomla/MockDatabaseDriver.php
@@ -1,0 +1,492 @@
+<?php
+/**
+ * Part of joomla341c project. 
+ *
+ * @copyright  Copyright (C) 2015 {ORGANIZATION}. All rights reserved.
+ * @license    GNU General Public License version 2 or later;
+ */
+
+namespace Windwalker\Test\Joomla;
+
+use JDatabaseDriver;
+use RuntimeException;
+
+/**
+ * The MockDatabaseDriver class.
+ * 
+ * @since  {DEPLOY_VERSION}
+ */
+class MockDatabaseDriver extends \JDatabaseDriver
+{
+	/**
+	 * Property executed.
+	 *
+	 * @var  array
+	 */
+	public $executed = array();
+
+	/**
+	 * mark
+	 *
+	 * @param string $method
+	 *
+	 * @return  static
+	 */
+	public function mark($method)
+	{
+		$this->executed[$method] = true;
+
+		return $this;
+	}
+
+	/**
+	 * executed
+	 *
+	 * @param string $method
+	 *
+	 * @return  boolean
+	 */
+	public function executed($method)
+	{
+		return !empty($this->executed[$method]);
+	}
+
+	/**
+	 * Class init.
+	 */
+	public function __construct()
+	{
+		parent::__construct(array());
+	}
+
+	/**
+	 * Test to see if the connector is available.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   11.2
+	 */
+	public static function isSupported()
+	{
+		return true;
+	}
+
+	/**
+	 * Connects to the database if needed.
+	 *
+	 * @return  void  Returns void if the database connected successfully.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function connect()
+	{
+		$this->mark(__FUNCTION__);
+	}
+
+	/**
+	 * Determines if the connection to the server is active.
+	 *
+	 * @return  boolean  True if connected to the database engine.
+	 *
+	 * @since   11.1
+	 */
+	public function connected()
+	{
+		$this->mark(__FUNCTION__);
+
+		return true;
+	}
+
+	/**
+	 * Disconnects the database.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function disconnect()
+	{
+		$this->mark(__FUNCTION__);
+	}
+
+	/**
+	 * Drops a table from the database.
+	 *
+	 * @param   string  $table    The name of the database table to drop.
+	 * @param   boolean $ifExists Optionally specify that the table must exist before it is dropped.
+	 *
+	 * @return  JDatabaseDriver     Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  RuntimeException
+	 */
+	public function dropTable($table, $ifExists = true)
+	{
+		$this->mark(__FUNCTION__);
+
+		return $this;
+	}
+
+	/**
+	 * Escapes a string for usage in an SQL statement.
+	 *
+	 * @param   string  $text  The string to be escaped.
+	 * @param   boolean $extra Optional parameter to provide extra escaping.
+	 *
+	 * @return  string   The escaped string.
+	 *
+	 * @since   11.1
+	 */
+	public function escape($text, $extra = false)
+	{
+		$this->mark(__FUNCTION__);
+
+		return $text;
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an array.
+	 *
+	 * @param   mixed $cursor The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   11.1
+	 */
+	protected function fetchArray($cursor = null)
+	{
+		$this->mark(__FUNCTION__);
+
+		return array();
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an associative array.
+	 *
+	 * @param   mixed $cursor The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   11.1
+	 */
+	protected function fetchAssoc($cursor = null)
+	{
+		$this->mark(__FUNCTION__);
+
+		return array();
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an object.
+	 *
+	 * @param   mixed  $cursor The optional result set cursor from which to fetch the row.
+	 * @param   string $class  The class name to use for the returned row object.
+	 *
+	 * @return  mixed   Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   11.1
+	 */
+	protected function fetchObject($cursor = null, $class = 'stdClass')
+	{
+		$this->mark(__FUNCTION__);
+
+		return new \stdClass;
+	}
+
+	/**
+	 * Method to free up the memory used for the result set.
+	 *
+	 * @param   mixed $cursor The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 */
+	protected function freeResult($cursor = null)
+	{
+		$this->mark(__FUNCTION__);
+	}
+
+	/**
+	 * Get the number of affected rows for the previous executed SQL statement.
+	 *
+	 * @return  integer  The number of affected rows.
+	 *
+	 * @since   11.1
+	 */
+	public function getAffectedRows()
+	{
+		$this->mark(__FUNCTION__);
+
+		return 123;
+	}
+
+	/**
+	 * Method to get the database collation in use by sampling a text field of a table in the database.
+	 *
+	 * @return  mixed  The collation in use by the database or boolean false if not supported.
+	 *
+	 * @since   11.1
+	 */
+	public function getCollation()
+	{
+		$this->mark(__FUNCTION__);
+
+		return 'UTF-8';
+	}
+
+	/**
+	 * Get the number of returned rows for the previous executed SQL statement.
+	 *
+	 * @param   resource $cursor An optional database cursor resource to extract the row count from.
+	 *
+	 * @return  integer   The number of returned rows.
+	 *
+	 * @since   11.1
+	 */
+	public function getNumRows($cursor = null)
+	{
+		$this->mark(__FUNCTION__);
+
+		return 321;
+	}
+
+	/**
+	 * Retrieves field information about the given tables.
+	 *
+	 * @param   string  $table    The name of the database table.
+	 * @param   boolean $typeOnly True (default) to only return field types.
+	 *
+	 * @return  array  An array of fields by table.
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableColumns($table, $typeOnly = true)
+	{
+		$this->mark(__FUNCTION__);
+
+		return array();
+	}
+
+	/**
+	 * Shows the table CREATE statement that creates the given tables.
+	 *
+	 * @param   mixed $tables A table name or a list of table names.
+	 *
+	 * @return  array  A list of the create SQL for the tables.
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableCreate($tables)
+	{
+		$this->mark(__FUNCTION__);
+
+		return array();
+	}
+
+	/**
+	 * Retrieves field information about the given tables.
+	 *
+	 * @param   mixed $tables A table name or a list of table names.
+	 *
+	 * @return  array  An array of keys for the table(s).
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableKeys($tables)
+	{
+		$this->mark(__FUNCTION__);
+
+		return array();
+	}
+
+	/**
+	 * Method to get an array of all tables in the database.
+	 *
+	 * @return  array  An array of all the tables in the database.
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableList()
+	{
+		$this->mark(__FUNCTION__);
+
+		return array();
+	}
+
+	/**
+	 * Get the version of the database connector
+	 *
+	 * @return  string  The database connector version.
+	 *
+	 * @since   11.1
+	 */
+	public function getVersion()
+	{
+		$this->mark(__FUNCTION__);
+
+		return '1.0';
+	}
+
+	/**
+	 * Method to get the auto-incremented value from the last INSERT statement.
+	 *
+	 * @return  mixed  The value of the auto-increment field from the last inserted row.
+	 *
+	 * @since   11.1
+	 */
+	public function insertid()
+	{
+		$this->mark(__FUNCTION__);
+
+		return 1221;
+	}
+
+	/**
+	 * Locks a table in the database.
+	 *
+	 * @param   string $tableName The name of the table to unlock.
+	 *
+	 * @return  JDatabaseDriver     Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  RuntimeException
+	 */
+	public function lockTable($tableName)
+	{
+		$this->mark(__FUNCTION__);
+
+		return $this;
+	}
+
+	/**
+	 * Renames a table in the database.
+	 *
+	 * @param   string $oldTable The name of the table to be renamed
+	 * @param   string $newTable The new name for the table.
+	 * @param   string $backup   Table prefix
+	 * @param   string $prefix   For the table - used to rename constraints in non-mysql databases
+	 *
+	 * @return  JDatabaseDriver    Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  RuntimeException
+	 */
+	public function renameTable($oldTable, $newTable, $backup = null, $prefix = null)
+	{
+		$this->mark(__FUNCTION__);
+
+		return $this;
+	}
+
+	/**
+	 * Select a database for use.
+	 *
+	 * @param   string $database The name of the database to select for use.
+	 *
+	 * @return  boolean  True if the database was successfully selected.
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function select($database)
+	{
+		$this->mark(__FUNCTION__);
+
+		return true;
+	}
+
+	/**
+	 * Set the connection to use UTF-8 character encoding.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   11.1
+	 */
+	public function setUTF()
+	{
+		$this->mark(__FUNCTION__);
+
+		return true;
+	}
+
+	/**
+	 * Method to commit a transaction.
+	 *
+	 * @param   boolean $toSavepoint If true, commit to the last savepoint.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function transactionCommit($toSavepoint = false)
+	{
+		$this->mark(__FUNCTION__);
+	}
+
+	/**
+	 * Method to roll back a transaction.
+	 *
+	 * @param   boolean $toSavepoint If true, rollback to the last savepoint.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function transactionRollback($toSavepoint = false)
+	{
+		$this->mark(__FUNCTION__);
+	}
+
+	/**
+	 * Method to initialize a transaction.
+	 *
+	 * @param   boolean $asSavepoint If true and a transaction is already active, a savepoint will be created.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function transactionStart($asSavepoint = false)
+	{
+		$this->mark(__FUNCTION__);
+	}
+
+	/**
+	 * Execute the SQL statement.
+	 *
+	 * @return  mixed  A database cursor resource on success, boolean false on failure.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function execute()
+	{
+		$this->mark(__FUNCTION__);
+
+		return true;
+	}
+
+	/**
+	 * Unlocks tables in the database.
+	 *
+	 * @return  JDatabaseDriver  Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  RuntimeException
+	 */
+	public function unlockTables()
+	{
+		$this->mark(__FUNCTION__);
+
+		return $this;
+	}
+}

--- a/test/Joomla/MockDatabaseDriver.php
+++ b/test/Joomla/MockDatabaseDriver.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Part of joomla341c project. 
+ * Part of Windwalker project.
  *
  * @copyright  Copyright (C) 2015 {ORGANIZATION}. All rights reserved.
  * @license    GNU General Public License version 2 or later;

--- a/test/Model/ModelTest.php
+++ b/test/Model/ModelTest.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Part of Windwalker project Test files.
+ *
+ * @copyright  Copyright (C) 2011 - 2014 SMS Taiwan, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Windwalker\Test\Model;
+
+require_once __DIR__ . '/Stub/WindwalkerModelStub.php';
+
+use Joomla\Registry\Registry;
+use Windwalker\DI\Container;
+use Windwalker\Test\Joomla\MockDatabaseDriver;
+use Windwalker\Test\Model\Stub\StubModel;
+use Windwalker\Test\TestHelper;
+
+/**
+ * Test class of {className}
+ *
+ * @since {DEPLOY_VERSION}
+ */
+class ModelTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * Test instance.
+	 *
+	 * @var \WindwalkerModelStub
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return void
+	 */
+	protected function setUp()
+	{
+		$this->instance = new \WindwalkerModelStub;
+	}
+
+	/**
+	 * Tears down the fixture, for example, closes a network connection.
+	 * This method is called after a test is executed.
+	 *
+	 * @return void
+	 */
+	protected function tearDown()
+	{
+	}
+	
+	/**
+	 * Method to test __construct().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::__construct
+	 */
+	public function test__construct()
+	{
+		// Test for raw class but with naming convention
+		$model = new \WindwalkerModelStub;
+
+		// Auto detect model position and name
+		$this->assertEquals('windwalker',          TestHelper::getValue($model, 'prefix'));
+		$this->assertEquals('com_windwalker',      TestHelper::getValue($model, 'option'));
+		$this->assertEquals('stub',                $model->getName());
+		$this->assertEquals('com_windwalker.stub', TestHelper::getValue($model, 'context'));
+
+		$this->assertEquals('onContentCleanCache',          TestHelper::getValue($model, 'eventCleanCache'));
+		$this->assertInstanceOf('Windwalker\DI\Container',  $model->getContainer());
+		$this->assertInstanceOf('Joomla\Registry\Registry', $model->getState());
+		$this->assertTrue($model->populateState);
+
+		// Test with config
+		$config = array(
+			'prefix' => 'flower',
+			'name'   => 'sakura',
+			'event_clean_cache' => 'onSakuraCleanCache',
+			'ignore_request'    => true
+		);
+
+		$state = new Registry;
+		$db = \JFactory::getDbo();
+		$container = new Container;
+
+		$model = new \WindwalkerModelStub($config, $container, $state, $db);
+
+		$this->assertEquals('flower',             TestHelper::getValue($model, 'prefix'));
+		$this->assertEquals('com_flower',         TestHelper::getValue($model, 'option'));
+		$this->assertEquals('sakura',             $model->getName());
+		$this->assertEquals('com_flower.sakura',  TestHelper::getValue($model, 'context'));
+		$this->assertEquals('onSakuraCleanCache', TestHelper::getValue($model, 'eventCleanCache'));
+		$this->assertSame($container,  $model->getContainer());
+		$this->assertSame($state, $model->getState());
+		$this->assertSame($db, $model->getDb());
+		$this->assertFalse($model->populateState);
+
+		// Test preset in class
+		$model = new StubModel;
+
+		$this->assertEquals('windwalker',          TestHelper::getValue($model, 'prefix'));
+		$this->assertEquals('com_windwalker',      TestHelper::getValue($model, 'option'));
+		$this->assertEquals('stub',                $model->getName());
+		$this->assertEquals('com_windwalker.stub', TestHelper::getValue($model, 'context'));
+		$this->assertEquals('onTestCleanCache',    TestHelper::getValue($model, 'eventCleanCache'));
+	}
+
+	/**
+	 * Method to test getName().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::getName
+	 */
+	public function testGetName()
+	{
+		$this->assertEquals('stub', $this->instance->getName());
+	}
+
+	/**
+	 * Method to test getTable().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::getTable
+	 */
+	public function testGetTable()
+	{
+		$this->assertInstanceOf('JTableContent', $this->instance->getTable('Content', 'JTable'));
+	}
+
+	/**
+	 * Method to test registerTablePaths().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::registerTablePaths
+	 */
+	public function testRegisterTablePaths()
+	{
+		$model = new \WindwalkerModelStub(array('table_path' => '/foo/bar'));
+
+		$this->assertTrue(in_array('/foo/bar', $model::$paths));
+	}
+
+	/**
+	 * Method to test setName().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::setName
+	 */
+	public function testSetName()
+	{
+		$this->instance->setName('flower');
+
+		$this->assertEquals('flower', $this->instance->getName());
+	}
+
+	/**
+	 * Method to test setOption().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::setOption
+	 */
+	public function testSetOption()
+	{
+		$this->instance->setOption('com_flower');
+
+		$this->assertEquals('com_flower', TestHelper::getValue($this->instance, 'option'));
+	}
+
+	/**
+	 * Method to test addTablePath().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::addTablePath
+	 */
+	public function testAddTablePath()
+	{
+		$this->instance->addTablePath('/flower/sakura');
+
+		$model = $this->instance;
+
+		$this->assertTrue(in_array('/flower/sakura', $model::$paths));
+	}
+
+	/**
+	 * Method to test getContainer().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::getContainer
+	 * @covers Windwalker\Model\Model::setContainer
+	 */
+	public function testGetAndSetContainer()
+	{
+		$container = new Container;
+
+		$this->instance->setContainer($container);
+
+		$this->assertSame($container, $this->instance->getContainer());
+	}
+
+	/**
+	 * Method to test get().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::get
+	 */
+	public function testGetAndSet()
+	{
+		$this->instance->set('pk', 5);
+
+		$item = $this->instance->getItem();
+
+		$this->assertEquals(5, $item->pk);
+
+		$this->assertEquals(5, $this->instance->get('pk'));
+		$this->assertEquals(6, $this->instance->get('none', 6));
+	}
+
+	/**
+	 * Method to test reset().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::reset
+	 */
+	public function testReset()
+	{
+		$this->instance->set('pk', 5);
+
+		$this->instance->reset();
+
+		$this->assertNull($this->instance->get('pk'));
+	}
+
+	/**
+	 * Method to test offsetExists().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::offsetExists
+	 */
+	public function testOffsetExists()
+	{
+		$this->instance->set('item.id', 5);
+
+		$this->assertTrue(isset($this->instance['item.id']));
+	}
+
+	/**
+	 * Method to test offsetGet().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::offsetGet
+	 * @covers Windwalker\Model\Model::offsetSet
+	 */
+	public function testOffsetGetAndSet()
+	{
+		$this->instance['item.id'] = 8;
+
+		$this->assertEquals(8, $this->instance['item.id']);
+	}
+
+	/**
+	 * Method to test offsetUnset().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::offsetUnset
+	 */
+	public function testOffsetUnset()
+	{
+		$this->instance['item.id'] = 9;
+
+		unset($this->instance['item.id']);
+
+		$this->assertNull($this->instance->get('item.id'));
+	}
+
+	/**
+	 * Method to test getDb().
+	 *
+	 * @return void
+	 *
+	 * @covers Windwalker\Model\Model::getDb
+	 */
+	public function testGetAndSetDb()
+	{
+		$db = new MockDatabaseDriver;
+
+		$this->instance->setDb($db);
+
+		$this->assertSame($db, $this->instance->getDb());
+	}
+}

--- a/test/Model/ModelTest.php
+++ b/test/Model/ModelTest.php
@@ -17,7 +17,7 @@ use Windwalker\Test\Model\Stub\StubModel;
 use Windwalker\Test\TestHelper;
 
 /**
- * Test class of {className}
+ * Test class of Model
  *
  * @since {DEPLOY_VERSION}
  */

--- a/test/Model/Stub/StubModel.php
+++ b/test/Model/Stub/StubModel.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Part of joomla341c project. 
+ *
+ * @copyright  Copyright (C) 2015 {ORGANIZATION}. All rights reserved.
+ * @license    GNU General Public License version 2 or later;
+ */
+
+namespace Windwalker\Test\Model\Stub;
+
+require_once __DIR__ . '/WindwalkerModelStub.php';
+
+/**
+ * The StubModel class.
+ * 
+ * @since  {DEPLOY_VERSION}
+ */
+class StubModel extends \WindwalkerModelStub
+{
+	/**
+	 * Property prefix.
+	 *
+	 * @var  string
+	 */
+	protected $prefix = 'windwalker';
+
+	/**
+	 * Property name.
+	 *
+	 * @var  string
+	 */
+	protected $name = 'stub';
+
+	/**
+	 * Property option.
+	 *
+	 * @var  string
+	 */
+	protected $option = 'com_windwalker';
+
+	/**
+	 * Property context.
+	 *
+	 * @var  string
+	 */
+	protected $context = 'com_windwalker.stub';
+
+	/**
+	 * Property eventCleanCache.
+	 *
+	 * @var  string
+	 */
+	protected $eventCleanCache = 'onTestCleanCache';
+}

--- a/test/Model/Stub/StubModel.php
+++ b/test/Model/Stub/StubModel.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Part of joomla341c project. 
+ * Part of Windwalker project.
  *
  * @copyright  Copyright (C) 2015 {ORGANIZATION}. All rights reserved.
  * @license    GNU General Public License version 2 or later;

--- a/test/Model/Stub/WindwalkerModelStub.php
+++ b/test/Model/Stub/WindwalkerModelStub.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Part of joomla341c project. 
+ *
+ * @copyright  Copyright (C) 2015 {ORGANIZATION}. All rights reserved.
+ * @license    GNU General Public License version 2 or later;
+ */
+
+use Windwalker\Data\Data;
+use Windwalker\Model\Model;
+
+/**
+ * The WindwalkerModelStub class.
+ * 
+ * @since  {DEPLOY_VERSION}
+ */
+class WindwalkerModelStub extends Model
+{
+	/**
+	 * Property populateState.
+	 *
+	 * @var  bool
+	 */
+	public $populateState = false;
+
+	/**
+	 * Property paths.
+	 *
+	 * @var  array
+	 */
+	public static $paths = array();
+
+	/**
+	 * getItem
+	 *
+	 * @param int $pk
+	 *
+	 * @return  Data
+	 */
+	public function getItem($pk = null)
+	{
+		$pk = $pk ? : $this->get('pk');
+
+		$data = new Data(array('pk' => $pk));
+
+		return $data;
+	}
+
+	/**
+	 * populateState
+	 *
+	 * @return  void
+	 */
+	protected function populateState()
+	{
+		$this->populateState = true;
+	}
+
+	/**
+	 * Adds to the stack of model table paths in LIFO order.
+	 *
+	 * @param   mixed  $path  The directory as a string or directories as an array to add.
+	 *
+	 * @return  void
+	 */
+	public static function addTablePath($path)
+	{
+		static::$paths[] = $path;
+	}
+}

--- a/test/Model/Stub/WindwalkerModelStub.php
+++ b/test/Model/Stub/WindwalkerModelStub.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Part of joomla341c project. 
+ * Part of Windwalker project.
  *
  * @copyright  Copyright (C) 2015 {ORGANIZATION}. All rights reserved.
  * @license    GNU General Public License version 2 or later;


### PR DESCRIPTION
加上從 Windwalker Framework 轉移過來的新功能

以後不用再很蠢的把 state 拿出來用了，Model 本身就可以直接 get() and set()

``` php
// 以前
$state = $model->getState();
$state->set('a', 1);
$state->set('b', 2);

// 現在
$model->set('a', 1)
    ->set('b', 2);
```

還可以用 Array Access

``` php
$model['item.id'] = 123;

$limit = $model['list.limit'];
```

另外加上了全 Model 的單元測試
