### PR TITLE
優化 Build 指令，移除不必要的檔案與依賴

### DIFF
--- a/bin/build.php
+++ b/bin/build.php
@@ -78,7 +78,7 @@ class Build
 		// Start ZIP archive
 		$zip = new ZipArchive;
 
-		@unlink();
+		@unlink($zipFile->getPathname());
 
 		$zip->open($zipFile->getPathname(), ZIPARCHIVE::CREATE);
 
@@ -121,7 +121,7 @@ class Build
 
 				foreach($files as $file) 
 				{
-        			$file->isDir() && !$file->isLink() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+					$file->isDir() && !$file->isLink() ? rmdir($file->getPathname()) : unlink($file->getPathname());
 				}
 
 				rmdir($path);

--- a/bin/build.php
+++ b/bin/build.php
@@ -22,7 +22,7 @@ class Build
 		'test',
 		'.gitignore',
 		'.travis.yml',
-		'phpunit.dist.xml',
+		'phpunit.xml.dist',
 		'README.md'
 	);
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "windwalker/filesystem": "~2.0@stable",
         "windwalker/console": "~2.0@stable",
         "asika/muse": "~1.0@stable",
-        "joomla/string": "~1.0@stable",
         "symfony/yaml": "2.*",
         "filp/whoops": "1.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a5cb646a6bcdbc9b4bc9b0c1e0be49dc",
+    "hash": "f8828e7474df8100016f740fb6e0accb",
     "packages": [
         {
             "name": "asika/muse",
@@ -59,16 +59,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "c982fe62c44798c433229cb0425c61b487cc1883"
+                "reference": "37b5e653c99cbb9113108d7dc59a0ddc306acc46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/c982fe62c44798c433229cb0425c61b487cc1883",
-                "reference": "c982fe62c44798c433229cb0425c61b487cc1883",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/37b5e653c99cbb9113108d7dc59a0ddc306acc46",
+                "reference": "37b5e653c99cbb9113108d7dc59a0ddc306acc46",
                 "shasum": ""
             },
             "require": {
@@ -113,72 +113,24 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2015-03-30 15:26:59"
-        },
-        {
-            "name": "joomla/string",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/joomla-framework/string.git",
-                "reference": "0df8ead8c726a1f648e624d3bcbef8cf05c1d0da"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/string/zipball/0df8ead8c726a1f648e624d3bcbef8cf05c1d0da",
-                "reference": "0df8ead8c726a1f648e624d3bcbef8cf05c1d0da",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.10"
-            },
-            "require-dev": {
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
-            },
-            "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Joomla\\String\\": "src/",
-                    "Joomla\\String\\Tests\\": "Tests/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "description": "Joomla String Package",
-            "homepage": "https://github.com/joomla-framework/string",
-            "keywords": [
-                "framework",
-                "joomla",
-                "string"
-            ],
-            "time": "2015-03-26 01:02:20"
+            "time": "2015-05-29 15:12:07"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.6",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4"
+                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/174f009ed36379a801109955fc5a71a49fe62dd4",
-                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4a29a5248aed4fb45f626a7bbbd330291492f5c3",
+                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
                 "symfony/phpunit-bridge": "~2.7"
@@ -186,11 +138,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
                 }
             },
@@ -200,17 +152,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:54:10"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:21:08"
         },
         {
             "name": "windwalker/cache",
@@ -821,8 +773,7 @@
         "windwalker/router": 0,
         "windwalker/filesystem": 0,
         "windwalker/console": 0,
-        "asika/muse": 0,
-        "joomla/string": 0
+        "asika/muse": 0
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="test/bootstrap.php" colors="false"
+<phpunit bootstrap="test/bootstrap.php"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,17 +3,10 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	strict="true"
 	syntaxCheck="true"
 	>
 	<php>
 		<ini name="error_reporting" value="32767" />
-
-		<!--<const name="WINDWALKER_TEST_DB_DSN_MYSQL"      value="host=localhost;dbname=windwalker_test;user=root;pass=ut1234;prefix=ww_" />-->
-		<!--<const name="WINDWALKER_TEST_DB_DSN_POSTGRESQL" value="host=localhost;dbname=windwalker_test;user=root;pass=ut1234;prefix=ww_" />-->
-		<!--<const name="WINDWALKER_TEST_DB_DSN_ORACLE"     value="host=localhost;port=5432;dbname=windwalker_test;user=root;pass=ut1234;prefix=ww_" />-->
-		<!--<const name="WINDWALKER_TEST_DB_DSN_MSSQL"      value="host=localhost;port=1521;dbname=windwalker_test;user=root;pass=ut1234;prefix=ww_" />-->
-		<!--<const name="WINDWALKER_TEST_DB_DSN_SQLITE"     value="host=localhost;dbname=windwalker_test;user=root;pass=ut1234;prefix=ww_" />-->
 	</php>
 	<testsuites>
 		<testsuite name="RAD">

--- a/windwalker.xml
+++ b/windwalker.xml
@@ -19,16 +19,11 @@
 		<folder>language</folder>
 		<folder>resource</folder>
 		<folder>src</folder>
-		<folder>test</folder>
 		<folder>vendor</folder>
-		<file>.gitignore</file>
-		<file>.travis.yml</file>
 		<file>composer.json</file>
 		<file>composer.lock</file>
 		<file>config.dist.json</file>
 		<file>index.html</file>
-		<file>phpunit.xml.dist</file>
-		<file>README.md</file>
 		<file>windwalker.xml</file>
 	</files>
 


### PR DESCRIPTION
簡單替整個包裝瘦身，build.php 加上欲刪除的檔案與資料夾，未來 test 目錄不會包在正式分發的包裝中。

另外更新 composer.lock ，移除 `joomla/string` （現在的 Joomla 都應該內建了）
## Build.php 的使用方式

將 Windwalker RAD clone 到任何地方，cd 進去執行

``` bash
php bin/build.php 2.1.0
```

就會開始 build 成正式的分派檔案，然後壓縮成一個 zip 包

@bblurock plz review this PR.
