### PR TITLE
Fix EOL for HtmlHelperTest in Windows

### DIFF
--- a/test/Helper/HtmlHelperTest.php
+++ b/test/Helper/HtmlHelperTest.php
@@ -9,13 +9,14 @@
 namespace Windwalker\Test\Helper;
 
 use Windwalker\Helper\HtmlHelper;
+use Windwalker\Test\TestCase\DomTestCase;
 
 /**
  * Test class of {className}
  *
  * @since {DEPLOY_VERSION}
  */
-class HtmlHelperTest extends \PHPUnit_Framework_TestCase
+class HtmlHelperTest extends DomTestCase
 {
 	/**
 	 * Tears down the fixture, for example, closes a network connection.
@@ -49,7 +50,7 @@ class HtmlHelperTest extends \PHPUnit_Framework_TestCase
 			return;
 		}
 
-		$this->assertSame($expected, HtmlHelper::repair($data));
+		$this->assertDomStringEqualsDomString($expected, HtmlHelper::repair($data));
 	}
 
 	/**
@@ -206,7 +207,7 @@ DATA_3;
 			return;
 		}
 
-		$this->assertSame($expected, HtmlHelper::repair($data));
+		$this->assertDomStringEqualsDomString($expected, HtmlHelper::repair($data));
 	}
 
 	/**


### PR DESCRIPTION
直接用 assert 做 string 比對，會碰到 Windows / Mac 換行標示（EOL）不同的影響

這個 PR 用 Windwalker Test package 內的 DomTestCase class 來解決此問題

![p-2015-06-10-002](https://cloud.githubusercontent.com/assets/1639206/8086366/a0baf3a2-0fc7-11e5-81fe-7dc5c755f9b2.jpg)

See: https://github.com/ventoviro/windwalker-test/blob/master/TestCase/DomTestCase.php#L31
