### PR TITLE
[Fix] 修復 LanguageHelper 不正確的 DI key 取得方式

### DIFF
--- a/src/Helper/LanguageHelper.php
+++ b/src/Helper/LanguageHelper.php
@@ -167,7 +167,7 @@ class LanguageHelper extends AbstractFacade
 	 */
 	public static function loadLanguage($ext, $client = 'site')
 	{
-		$lang = Container::getInstance()->get(static::$key);
+		$lang = Container::getInstance()->get(static::getDIKey());
 
 		return $lang->load($ext, JPATH_BASE, null, false, false)
 			|| $lang->load($ext, PathHelper::get($ext, $client), null, false, false)


### PR DESCRIPTION
改用 `getDIKey()` 而非 `static::$Key`

在正式環境會報錯 （又是一個 test 測不出來的東西...） 
