### PR TITLE
[Refactor] 從 ListModel 解耦 Container 並改寫 Database 系列的 classes

### DIFF
--- a/src/Joomla/Database/DatabaseCommand.php
+++ b/src/Joomla/Database/DatabaseCommand.php
@@ -9,9 +9,12 @@
 namespace Windwalker\Joomla\Database;
 
 use JDatabaseDriver as DatabaseDriver;
+use Windwalker\Helper\DatabaseHelper;
 
 /**
  * Some Useful function for database operation.
+ *
+ * @deprecated  3.0  Use DatabaseHelper instead.
  */
 class DatabaseCommand
 {
@@ -60,7 +63,7 @@ class DatabaseCommand
 		$query = QueryHelper::buildWheres($query, $conditions);
 
 		// Build update values.
-		$fields = array_keys($this->getColumns($table));
+		$fields = array_keys(DatabaseHelper::getColumns($table));
 
 		$hasField = false;
 

--- a/src/Joomla/Database/DatabaseFactory.php
+++ b/src/Joomla/Database/DatabaseFactory.php
@@ -13,6 +13,8 @@ use Windwalker\DI\Container;
 
 /**
  * Class DatabaseFactory
+ *
+ * @deprecated  3.0
  */
 abstract class DatabaseFactory
 {
@@ -37,6 +39,8 @@ abstract class DatabaseFactory
 	 * @param bool  $forceNew
 	 *
 	 * @return  DatabaseDriver
+	 *
+	 * @deprecated  3.0
 	 */
 	public static function getDbo($option = array(), $forceNew = false)
 	{
@@ -49,6 +53,8 @@ abstract class DatabaseFactory
 	 * @param   DatabaseDriver $db
 	 *
 	 * @return  void
+	 *
+	 * @deprecated  3.0
 	 */
 	public static function setDbo(DatabaseDriver $db)
 	{
@@ -61,6 +67,8 @@ abstract class DatabaseFactory
 	 * @param bool $forceNew
 	 *
 	 * @return  DatabaseCommand
+	 *
+	 * @deprecated  3.0
 	 */
 	public static function getCommand($forceNew = false)
 	{
@@ -77,7 +85,9 @@ abstract class DatabaseFactory
 	 *
 	 * @param   DatabaseCommand $command
 	 *
-	 * @return  DatabaseFactory  Return self to support chaining.
+	 * @return  void
+	 *
+	 * @deprectaed  3.0
 	 */
 	public static function setCommand(DatabaseCommand $command)
 	{

--- a/src/Joomla/Database/QueryHelper.php
+++ b/src/Joomla/Database/QueryHelper.php
@@ -8,10 +8,12 @@
 
 namespace Windwalker\Joomla\Database;
 
-use JDatabaseDriver as DatabaseDriver;
-use JDatabaseQuery as DatabaseQuery;
+use JDatabaseDriver as AbstractDatabaseDriver;
+use JDatabaseQuery as Query;
 use JDatabaseQueryElement as QueryElement;
 use Windwalker\Compare\Compare;
+use Windwalker\DI\Container;
+use Windwalker\Helper\DatabaseHelper;
 
 /**
  * Class QueryHelper
@@ -19,27 +21,9 @@ use Windwalker\Compare\Compare;
 class QueryHelper
 {
 	/**
-	 * THe first table only select columns' name.
-	 *
-	 * For example: `item.title AS title`
-	 *
-	 * @const integer
-	 */
-	const COLS_WITH_FIRST = 1;
-
-	/**
-	 * The first table select column with prefix as alias.
-	 *
-	 * For example: `item.title AS item_title`
-	 *
-	 * @const integer
-	 */
-	const COLS_PREFIX_WITH_FIRST = 2;
-
-	/**
 	 * Property db.
 	 *
-	 * @var  DatabaseDriver
+	 * @var  AbstractDatabaseDriver
 	 */
 	protected $db = null;
 
@@ -53,9 +37,9 @@ class QueryHelper
 	/**
 	 * Constructor.
 	 *
-	 * @param DatabaseDriver $db
+	 * @param AbstractDatabaseDriver $db
 	 */
-	public function __construct(DatabaseDriver $db = null)
+	public function __construct(AbstractDatabaseDriver $db = null)
 	{
 		$this->db = $db ? : $this->getDb();
 	}
@@ -63,14 +47,15 @@ class QueryHelper
 	/**
 	 * addTable
 	 *
-	 * @param string $alias
-	 * @param string $table
-	 * @param mixed  $condition
-	 * @param string $joinType
+	 * @param string  $alias
+	 * @param string  $table
+	 * @param mixed   $condition
+	 * @param string  $joinType
+	 * @param boolean $prefix
 	 *
 	 * @return  QueryHelper
 	 */
-	public function addTable($alias, $table, $condition = null, $joinType = 'LEFT')
+	public function addTable($alias, $table, $condition = null, $joinType = 'LEFT', $prefix = null)
 	{
 		$tableStorage = array();
 
@@ -95,6 +80,7 @@ class QueryHelper
 		$condition = preg_replace('/\s(?=\s)/', '', $condition);
 
 		$tableStorage['condition'] = trim($condition);
+		$tableStorage['prefix'] = $prefix;
 
 		$this->tables[$alias] = $tableStorage;
 
@@ -121,11 +107,9 @@ class QueryHelper
 	/**
 	 * getFilterFields
 	 *
-	 * @param int $prefixFirst
-	 *
 	 * @return  array
 	 */
-	public function getSelectFields($prefixFirst = self::COLS_WITH_FIRST)
+	public function getSelectFields()
 	{
 		$fields = array();
 
@@ -133,25 +117,28 @@ class QueryHelper
 
 		foreach ($this->tables as $alias => $table)
 		{
-			$columns = DatabaseFactory::getCommand()->getColumns($table['name']);
+			$columns = DatabaseHelper::getColumns($table);
 
-			foreach ($columns as $column => $var)
+			foreach ($columns as $column)
 			{
+				$prefix = $table['prefix'];
+
 				if ($i === 0)
 				{
-					if ($prefixFirst & self::COLS_WITH_FIRST)
-					{
-						$fields[] = $this->db->quoteName("{$alias}.{$column}", $column);
-					}
-
-					if ($prefixFirst & self::COLS_PREFIX_WITH_FIRST)
-					{
-						$fields[] = $this->db->quoteName("{$alias}.{$column}", "{$alias}_{$column}");
-					}
+					$prefix = $prefix === null ? false : true;
 				}
 				else
 				{
-					$fields[] = $this->db->quoteName("{$alias}.{$column}", "{$alias}_{$column}");
+					$prefix = $prefix === null ? true : false;
+				}
+
+				if ($prefix === true)
+				{
+					$fields[] = $this->db->quoteName("{$alias}.{$column} AS {$alias}_{$column}");
+				}
+				else
+				{
+					$fields[] = $this->db->quoteName("{$alias}.{$column} AS {$column}");
 				}
 			}
 
@@ -164,11 +151,11 @@ class QueryHelper
 	/**
 	 * registerQueryTables
 	 *
-	 * @param DatabaseQuery $query
+	 * @param Query $query
 	 *
-	 * @return  DatabaseQuery
+	 * @return  Query
 	 */
-	public function registerQueryTables(DatabaseQuery $query)
+	public function registerQueryTables(Query $query)
 	{
 		foreach ($this->tables as $alias => $table)
 		{
@@ -191,22 +178,23 @@ class QueryHelper
 	/**
 	 * buildConditions
 	 *
-	 * @param DatabaseQuery $query
+	 * @param Query $query
 	 * @param array         $conditions
 	 *
-	 * @return  DatabaseQuery
+	 * @return  Query
 	 */
-	public static function buildWheres(DatabaseQuery $query, array $conditions)
+	public static function buildWheres(Query $query, array $conditions)
 	{
 		foreach ($conditions as $key => $value)
 		{
-			if (empty($value))
+			// NULL
+			if ($value === null)
 			{
-				continue;
+				$query->where($query->format('%n = NULL', $key));
 			}
 
 			// If using Compare class, we convert it to string.
-			if ($value instanceof Compare)
+			elseif ($value instanceof Compare)
 			{
 				$query->where((string) static::buildCompare($key, $value, $query));
 			}
@@ -214,7 +202,7 @@ class QueryHelper
 			// If key is numeric, just send value to query where.
 			elseif (is_numeric($key))
 			{
-				$query->where((string) $value);
+				$query->where($query->format('%n = %a', $key, $value));
 			}
 
 			// If is array or object, we use "IN" condition.
@@ -238,15 +226,16 @@ class QueryHelper
 	/**
 	 * buildCompare
 	 *
-	 * @param string|int    $key
-	 * @param Compare       $value
-	 * @param DatabaseQuery $query
+	 * @param string|int  $key
+	 * @param Compare     $value
+	 * @param Query       $query
 	 *
 	 * @return  string
 	 */
 	public static function buildCompare($key, Compare $value, $query = null)
 	{
-		$query = $query ? : DatabaseFactory::getDbo()->getQuery(true);
+		/** @var Query $query */
+		$query = $query ? : Container::getInstance()->get('db')->getQuery(true);
 
 		if (!is_numeric($key))
 		{
@@ -266,13 +255,13 @@ class QueryHelper
 	/**
 	 * getDb
 	 *
-	 * @return  DatabaseDriver
+	 * @return  AbstractDatabaseDriver
 	 */
 	public function getDb()
 	{
 		if (!$this->db)
 		{
-			$this->db = DatabaseFactory::getDbo();
+			$this->db = Container::getInstance()->get('db');
 		}
 
 		return $this->db;
@@ -281,13 +270,37 @@ class QueryHelper
 	/**
 	 * setDb
 	 *
-	 * @param   DatabaseDriver $db
+	 * @param   AbstractDatabaseDriver $db
 	 *
 	 * @return  QueryHelper  Return self to support chaining.
 	 */
 	public function setDb($db)
 	{
 		$this->db = $db;
+
+		return $this;
+	}
+
+	/**
+	 * Method to get property Tables
+	 *
+	 * @return  array
+	 */
+	public function getTables()
+	{
+		return $this->tables;
+	}
+
+	/**
+	 * Method to set property tables
+	 *
+	 * @param   array $tables
+	 *
+	 * @return  static  Return self to support chaining.
+	 */
+	public function setTables($tables)
+	{
+		$this->tables = $tables;
 
 		return $this;
 	}

--- a/src/Model/Helper/QueryHelper.php
+++ b/src/Model/Helper/QueryHelper.php
@@ -9,6 +9,7 @@
 namespace Windwalker\Model\Helper;
 
 use Windwalker\DI\Container;
+use Windwalker\Helper\DatabaseHelper;
 use Windwalker\Helper\DateHelper;
 use Windwalker\Joomla\Database\DatabaseFactory;
 
@@ -30,7 +31,7 @@ class QueryHelper extends \Windwalker\Joomla\Database\QueryHelper
 
 		foreach ($this->tables as $alias => $table)
 		{
-			$columns = DatabaseFactory::getCommand()->getColumns($table['name']);
+			$columns = DatabaseHelper::getColumns($table['name']);
 
 			foreach ($columns as $key => $var)
 			{

--- a/src/Model/ListModel.php
+++ b/src/Model/ListModel.php
@@ -93,6 +93,27 @@ class ListModel extends FormModel
 	protected $selectType = null;
 
 	/**
+	 * Property queryHelper.
+	 *
+	 * @var  QueryHelper
+	 */
+	protected $queryHelper;
+
+	/**
+	 * Property filterHelper.
+	 *
+	 * @var  FilterHelper
+	 */
+	protected $filterHelper;
+
+	/**
+	 * Property searchHelper.
+	 *
+	 * @var  SearchHelper
+	 */
+	protected $searchHelper;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array              $config    An array of configuration options (name, state, dbo, table_path, ignore_request).
@@ -120,7 +141,7 @@ class ListModel extends FormModel
 
 		$this->container = $container ? : $this->getContainer();
 
-		$this->container->registerServiceProvider(new GridProvider($this->name));
+		$this->container->registerServiceProvider(new GridProvider($this->name, $this));
 
 		$this->configureTables();
 
@@ -695,7 +716,7 @@ class ListModel extends FormModel
 	{
 		$filters = $filters ? : $this->state->get('filter', array());
 
-		$filterHelper = $this->container->get('model.' . strtolower($this->name) . '.filter', Container::FORCE_NEW);
+		$filterHelper = $this->getFilterHelper();
 
 		$this->configureFilters($filterHelper);
 
@@ -739,7 +760,7 @@ class ListModel extends FormModel
 	{
 		$searches = $searches ? : $this->state->get('search', array());
 
-		$searchHelper = $this->container->get('model.' . strtolower($this->name) . '.search', Container::FORCE_NEW);
+		$searchHelper = $this->getSearchHelper();
 
 		$this->configureSearches($searchHelper);
 
@@ -916,7 +937,7 @@ class ListModel extends FormModel
 	 */
 	public function addTable($alias, $table, $condition = null, $joinType = 'LEFT')
 	{
-		$queryHelper = $this->getContainer()->get('model.' . $this->name . '.helper.query');
+		$queryHelper = $this->getQueryHelper();
 
 		$queryHelper->addTable($alias, $table, $condition, $joinType);
 
@@ -932,9 +953,96 @@ class ListModel extends FormModel
 	 */
 	public function removeTable($alias)
 	{
-		$queryHelper = $this->getContainer()->get('model.' . $this->name . '.helper.query');
+		$queryHelper = $this->getQueryHelper();
 
 		$queryHelper->removeTable($alias);
+
+		return $this;
+	}
+
+	/**
+	 * Method to get property QueryHelper
+	 *
+	 * @return  QueryHelper
+	 */
+	public function getQueryHelper()
+	{
+		if (!$this->queryHelper)
+		{
+			$this->queryHelper = new QueryHelper;
+		}
+
+		return $this->queryHelper;
+	}
+
+	/**
+	 * Method to set property queryHelper
+	 *
+	 * @param   QueryHelper $queryHelper
+	 *
+	 * @return  static  Return self to support chaining.
+	 */
+	public function setQueryHelper(QueryHelper $queryHelper)
+	{
+		$this->queryHelper = $queryHelper;
+
+		return $this;
+	}
+
+	/**
+	 * Method to get property FilterHelper
+	 *
+	 * @return  FilterHelper
+	 */
+	public function getFilterHelper()
+	{
+		if (!$this->filterHelper)
+		{
+			$this->filterHelper = new FilterHelper;
+		}
+
+		return $this->filterHelper;
+	}
+
+	/**
+	 * Method to set property filterHelper
+	 *
+	 * @param   FilterHelper $filterHelper
+	 *
+	 * @return  static  Return self to support chaining.
+	 */
+	public function setFilterHelper($filterHelper)
+	{
+		$this->filterHelper = $filterHelper;
+
+		return $this;
+	}
+
+	/**
+	 * Method to get property SearchHelper
+	 *
+	 * @return  SearchHelper
+	 */
+	public function getSearchHelper()
+	{
+		if (!$this->searchHelper)
+		{
+			$this->searchHelper = new SearchHelper;
+		}
+
+		return $this->searchHelper;
+	}
+
+	/**
+	 * Method to set property searchHelper
+	 *
+	 * @param   SearchHelper $searchHelper
+	 *
+	 * @return  static  Return self to support chaining.
+	 */
+	public function setSearchHelper($searchHelper)
+	{
+		$this->searchHelper = $searchHelper;
 
 		return $this;
 	}

--- a/test/DataMapper/OneToManyRelationTest.php
+++ b/test/DataMapper/OneToManyRelationTest.php
@@ -146,7 +146,7 @@ class OneToManyRelationTest extends AbstractDatabaseTestCase
 		$this->assertInstanceOf('Windwalker\Data\Data', $location2->roses[1]);
 		$this->assertEquals(array('Rose Create 1', 'Rose Create 2'), $location2->roses->title);
 
-		$locationData = DataMapperFacade::findOne(static::TABLE_LOCATIONS, null, 'id DESC');
+		$locationData = DataMapperFacade::findOne(static::TABLE_LOCATIONS, array(), 'id DESC');
 
 		$this->assertEquals('Location Create 1', $locationData->title);
 	}

--- a/test/Model/ListModelTest.php
+++ b/test/Model/ListModelTest.php
@@ -11,6 +11,7 @@ namespace Windwalker\Test\Model;
 use Windwalker\DI\Container;
 use Windwalker\Model\ListModel;
 use Windwalker\Model\Provider\GridProvider;
+use Windwalker\Test\Database\AbstractDatabaseTestCase;
 use Windwalker\Test\Model\Stub\WindwalkerModelStubList;
 use Windwalker\Test\TestHelper;
 
@@ -19,8 +20,28 @@ use Windwalker\Test\TestHelper;
  *
  * @since {DEPLOY_VERSION}
  */
-class ListModelTest extends \PHPUnit_Framework_TestCase
+class ListModelTest extends AbstractDatabaseTestCase
 {
+	/**
+	 * Install test sql when setUp.
+	 *
+	 * @return  string
+	 */
+	public static function getInstallSql()
+	{
+		return __DIR__ . '/sql/install.listmodel.sql';
+	}
+
+	/**
+	 * Uninstall test sql when tearDown.
+	 *
+	 * @return  string
+	 */
+	public static function getUninstallSql()
+	{
+		return __DIR__ . '/sql/install.listmodel.sql';
+	}
+
 	/**
 	 * setUpBeforeClass
 	 *
@@ -28,25 +49,13 @@ class ListModelTest extends \PHPUnit_Framework_TestCase
 	 */
 	public static function setUpBeforeClass()
 	{
-		$db = \JFactory::getDbo();
-		$sqls = file_get_contents(__DIR__ . '/sql/install.listmodel.sql');
-
-		foreach ($db->splitSql($sqls) as $sql)
-		{
-			$sql = trim($sql);
-
-			if (!empty($sql))
-			{
-				$db->setQuery($sql)->execute();
-			}
-		}
+		parent::setUpBeforeClass();
 
 		// Write filter.xml
 		$formPath = JPATH_BASE . '/components/com_stub/model/form/posts';
 
 		mkdir($formPath, 0777, true);
 		copy(__DIR__ . '/form/posts/filter.xml', $formPath . '/filter.xml');
-
 	}
 
 	/**
@@ -56,9 +65,7 @@ class ListModelTest extends \PHPUnit_Framework_TestCase
 	 */
 	public static function tearDownAfterClass()
 	{
-		$sql = file_get_contents(__DIR__ . '/sql/uninstall.listmodel.sql');
-
-		\JFactory::getDbo()->setQuery($sql)->execute();
+		parent::tearDownAfterClass();
 
 		// Remove filter.xml
 		$formPath = JPATH_BASE . '/components/com_stub/model/form/posts';
@@ -144,12 +151,8 @@ class ListModelTest extends \PHPUnit_Framework_TestCase
 	{
 		$container = $this->getMockBuilder('Windwalker\DI\Container')
 			->disableOriginalConstructor()
-			->setMethods(array('registerServiceProvider', 'get'))
+			->setMethods(array('get'))
 			->getMock();
-
-		$container->expects($this->once())
-			->method('registerServiceProvider')
-			->with(new GridProvider($config['name']));
 
 		$config = $this->getMockBuilder('JConfig')
 			->disableOriginalConstructor()
@@ -161,12 +164,12 @@ class ListModelTest extends \PHPUnit_Framework_TestCase
 			->with('list_limit')
 			->will($this->returnValue(100));
 
-		$container->expects($this->at(1))
+		$container->expects($this->at(0))
 			->method('get')
 			->with('joomla.config')
 			->will($this->returnValue($config));
 
-		$container->expects($this->at(2))
+		$container->expects($this->at(1))
 			->method('get')
 			->with('app')
 			->will($this->returnValue(Container::getInstance()->get('app')));
@@ -516,39 +519,24 @@ class ListModelTest extends \PHPUnit_Framework_TestCase
 	{
 		$config = array(
 			'prefix' => 'foo',
-			'name' => 'bar',
+			'name'   => 'bar',
 		);
-		$listModel = new ListModel($config, $this->getAddTableContainer($config));
 
-		$listModel->addTable('alias', '#__foobar', 'foo=123', 'LEFT');
-	}
+		$listModel = new ListModel($config);
 
-	/**
-	 * getAddTableContainer
-	 *
-	 * @param array $config
-	 *
-	 * @return \PHPUnit_Framework_MockObject_MockObject
-	 */
-	public function getAddTableContainer(array $config = array())
-	{
-		$container = $this->getConstructContainer($config);
-
-		$queryHelper = $this->getMockBuilder('Windwalker\Model\Helper\QueryHelper')
-			->disableOriginalConstructor()
+		$mock = $this->getMockBuilder('\Windwalker\Model\Helper\QueryHelper')
 			->setMethods(array('addTable'))
 			->getMock();
 
-		$queryHelper->expects($this->once())
+		$mock->expects($this->once())
 			->method('addTable')
 			->with('alias', '#__foobar', 'foo=123', 'LEFT');
 
-		$container->expects($this->at(3))
-			->method('get')
-			->with('model.bar.helper.query')
-			->will($this->returnValue($queryHelper));
+		$listModel->setQueryHelper($mock);
 
-		return $container;
+		$listModel->removeTable('alias');
+
+		$listModel->addTable('alias', '#__foobar', 'foo=123', 'LEFT');
 	}
 
 	/**
@@ -564,37 +552,19 @@ class ListModelTest extends \PHPUnit_Framework_TestCase
 			'prefix' => 'foo',
 			'name' => 'bar',
 		);
-		$listModel = new ListModel($config, $this->getRemoveTableContainer($config));
+		$listModel = new ListModel($config);
 
-		$listModel->removeTable('alias');
-	}
-
-	/**
-	 * getRemoveTableContainer
-	 *
-	 * @param array $config
-	 *
-	 * @return \PHPUnit_Framework_MockObject_MockObject
-	 */
-	public function getRemoveTableContainer(array $config = array())
-	{
-		$container = $this->getConstructContainer($config);
-
-		$queryHelper = $this->getMockBuilder('Windwalker\Model\Helper\QueryHelper')
-			->disableOriginalConstructor()
+		$mock = $this->getMockBuilder('\Windwalker\Model\Helper\QueryHelper')
 			->setMethods(array('removeTable'))
 			->getMock();
 
-		$queryHelper->expects($this->once())
+		$listModel->setQueryHelper($mock);
+
+		$mock->expects($this->once())
 			->method('removeTable')
 			->with('alias');
 
-		$container->expects($this->at(3))
-			->method('get')
-			->with('model.bar.helper.query')
-			->will($this->returnValue($queryHelper));
-
-		return $container;
+		$listModel->removeTable('alias');
 	}
 
 	/**

--- a/test/Relation/OneToManyRelationTest.php
+++ b/test/Relation/OneToManyRelationTest.php
@@ -136,7 +136,7 @@ class OneToManyRelationTest extends AbstractDatabaseTestCase
 		$this->assertInstanceOf('Windwalker\Data\Data', $location2->roses[1]);
 		$this->assertEquals(array('Rose Create 1', 'Rose Create 2'), $location2->roses->title);
 
-		$locationData = DataMapperFacade::findOne(static::TABLE_LOCATIONS, null, 'id DESC');
+		$locationData = DataMapperFacade::findOne(static::TABLE_LOCATIONS, array(), 'id DESC');
 
 		$this->assertEquals('Location Create 1', $locationData->title);
 	}


### PR DESCRIPTION
Ref: https://github.com/smstw/windwalker-joomla-rad/issues/15
- ListModel 內的 Query / Filter / Search 不再從 Container 拿出來
- 改寫 QueryHelper 用最新版架構
- DatabaseCommand 的任務全部轉移到 DatabaseHelper
- 調整一些測試以符合這次的修改

@LeoOnTheEarth plz review this
